### PR TITLE
Add project setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{java,gradle,xml}]
+indent_size = 4

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+sandbox/
+coverage/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,46 @@
+{
+    "parser": "babel-eslint",
+    "env": {
+        "browser": true,
+        "jest": true,
+        "node":  true,
+        "es6":   true,
+    },
+    "ecmaFeatures": {
+      "jsx": true,
+    },
+    "plugins": [
+        "react",
+         "react-native",
+    ],
+    "globals": {
+        "__DEV__": true,
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"
+    ],
+    "rules": {
+        quotes: ["error", "single"],
+        no-extra-boolean-cast: 0,
+        no-case-declarations: 0,
+        react/display-name: 0,
+        keyword-spacing: ["error", { "after": true, "before": true }],
+        eqeqeq: ["error", "always"],
+        "comma-dangle": ["error", {
+            "arrays": "ignore",
+            "objects": "always-multiline",
+            "imports": "always-multiline",
+            "exports": "ignore",
+            "functions": "ignore",
+        }],
+        space-before-blocks: ["error", "always"],
+        react/self-closing-comp: ["error", {"component": true}],
+        react/jsx-max-props-per-line: ["error", { "maximum": 1, "when": "always" }],
+        react/jsx-space-before-closing: 2,
+        react/jsx-indent-props: ["error", 2],
+        react-native/no-unused-styles: 2,
+        no-multiple-empty-lines: ["error", { "max": 1, "maxBOF": 1 }],
+        semi: ["error", "never"],
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# react-native-starter-kit
+# React native starter kit
+
+1. Setup your machine.
+- [Ubuntu setup](ubuntu-setup.md)
+- [Mac OS](https://facebook.github.io/react-native/docs/getting-started.html) - Select the option Building Projects with Native Code.
+- We highly recommend to use [Yarn](https://yarnpkg.com/en/docs/install).
+
+2. Start the project.
+```
+git clone git@github.com:Codeminer42/react-native-starter-kit.git yourProject
+react-native init yourProject (Type y if any prompt appears)
+cd yourProject
+rm -rf .git
+```
+
+3. Install the packages.
+
+`yarn add react-native-router-flux react-redux redux redux-thunk`
+
+`yarn add eslint eslint-plugin-react eslint-plugin-react-native --dev`
+
+4. Override the scripts.
+
+```
+  "scripts": {
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "test": "jest",
+    "coverage": "jest --coverage --silent && open coverage/lcov-report/index.html",
+    "coverage:open": "open coverage/lcov-report/index.html",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "release:android": "cd android && ./gradlew assembleRelease",
+    "open:android:release": "open android/app/build/outputs/apk",
+    "lint": "eslint -c .eslintrc . --ignore-path .eslintignore",
+    "lint:fix": "eslint -c .eslintrc . --ignore-path .eslintignore --fix"
+  },
+```
+
+5. Override your `index.ios.js` and `index.android.js` files.
+
+```
+import { AppRegistry } from 'react-native'
+
+import yourProject from './src/app'
+
+AppRegistry.registerComponent('yourProject', () => yourProject)
+```
+
+6. Run `yarn ios` or `yarn android`.

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,50 @@
+/**
+ * Sample React Native App
+ * https://github.com/facebook/react-native
+ * @flow
+ */
+
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View
+} from 'react-native';
+
+export default class AwesomeProject extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>
+          Welcome to React Native!
+        </Text>
+        <Text style={styles.instructions}>
+          To get started, edit index.android.js
+        </Text>
+        <Text style={styles.instructions}>
+          Double tap R on your keyboard to reload,{'\n'}
+          Shake or press menu button for dev menu
+        </Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});


### PR DESCRIPTION
Some remarks about the topics that I included on the `readme.md` file:

Topic 2: To test it, just need to clone in this branch: `git clone -b add-project-setup git@github.com:Codeminer42/react-native-starter-kit.git yourProject`.
Topic 3: We need to use a script/automation tool like Make or Rake.
Topic 4: We need to define a way to include those scripts automatically in the `package.json`, because React Native CLI has already created for us.
Topic 5: I guess this can be a pretty way to insert our boilerplate, just to keep our code inside `src`, and only changing the `index.ios.js` and `index.android.js`.